### PR TITLE
Compatibility changes for use with Atlas.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ setup(
     zip_safe=False,
     tests_require=["pytest"],
     install_requires=["numpy", "pandas", "scikit-learn",
-                      "matplotlib", "seaborn", "SQLAlchemy==1.4.45"],
-    python_requires=">=3.6",
+                      "matplotlib<=3.7.3", "seaborn", "SQLAlchemy==1.4.45"],
+    python_requires=">=3.7",
     extras_require=get_extra_requires("extra_requirements.txt"),
     entry_points={
         "console_scripts": ["olympus = olympus.cli.main:entry_point"]

--- a/src/olympus/datasets/dataset.py
+++ b/src/olympus/datasets/dataset.py
@@ -534,7 +534,7 @@ class Dataset:
         self.cross_val_indices = []
         for i in range(self.num_folds):
             fold_train = np.concatenate(
-                np.delete(self.cv_fold_indices, i, axis=0), axis=0
+                np.delete(np.array(self.cv_fold_indices, dtype=object), i, axis=0), axis=0
             )
             fold_valid = self.cv_fold_indices[i]
             self.cross_val_indices.append([fold_train, fold_valid])


### PR DESCRIPTION
Add changes to work with Atlas.

Python requires at least 3.8
Matplotlib should only be up to version 3.7
Error in `dataset.py` regarding inhomogeneous numpy array.
