### PR TITLE
fixed for matplotlib 3.9

### DIFF
--- a/src/olympus/plotter/olympus_colors.py
+++ b/src/olympus/plotter/olympus_colors.py
@@ -4,7 +4,7 @@
 # Define Olympus colors
 # =====================
 
-import matplotlib.pyplot as plt
+import matplotlib as mpl
 import numpy as np
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -24,10 +24,10 @@ _olympus_cmap_r = LinearSegmentedColormap.from_list(
     "olympus_r", _olympus_reference_colors[::-1]
 )
 
-plt.register_cmap(cmap=_olympus_cmap)
-plt.register_cmap(cmap=_olympus_cmap_r)
+mpl.colormaps.register(cmap=_olympus_cmap)
+mpl.colormaps.register(cmap=_olympus_cmap_r)
 
 
 def get_olympus_colors(n):
-    olympus_cmap = plt.get_cmap("olympus")
+    olympus_cmap = mpl.colormaps.get_cmap("olympus")
     return [olympus_cmap(x) for x in np.linspace(0, 1, n)]


### PR DESCRIPTION
Hello, 

very simple fix, changed the registration and loading of the matplotlib colormaps to fit with MPL 3.9. 

I needed this for my own work so thought would be a nice way to give back to fix this little bug for you guys.


Cheers, 
Elia